### PR TITLE
don't specify dot character in available subtitle formats in the CLI

### DIFF
--- a/src/subsai/cli.py
+++ b/src/subsai/cli.py
@@ -124,7 +124,7 @@ def main():
                              "string)")
     parser.add_argument('-f', '--format', '--subtitles-format', default='srt',
                         help=f"Output subtitles format, available "
-                             f"formats {available_subs_formats()}")
+                             f"formats {available_subs_formats(include_extensions=False)}")
     parser.add_argument('-df', '--destination-folder', default=None,
                         help='The directory where the subtitles will be stored, default to the same folder where '
                              'the media file(s) is stored.')

--- a/src/subsai/utils.py
+++ b/src/subsai/utils.py
@@ -48,11 +48,20 @@ def available_translation_models() -> list:
     return models
 
 
-def available_subs_formats():
+def available_subs_formats(include_extensions=True):
     """
     Returns available subtitle formats
     from :attr:`pysubs2.FILE_EXTENSION_TO_FORMAT_IDENTIFIER`
 
+    :param include_extensions: include the dot separator in file extensions
+
     :return: list of subtitle formats
     """
-    return list(FILE_EXTENSION_TO_FORMAT_IDENTIFIER.keys())
+
+    extensions = list(FILE_EXTENSION_TO_FORMAT_IDENTIFIER.keys())
+
+    if include_extensions:
+        return extensions
+    else:
+        # remove the '.' separator from extension names
+        return [ext.split('.')[1] for ext in extensions]


### PR DESCRIPTION
Running `subsai --help` seems to specify to the user that they should include a dot in the subtitle format:
```console
asolidtime ~> subsai --help
[lines excluded]
  -f FORMAT, --format FORMAT, --subtitles-format FORMAT
                        Output subtitles format, available formats ['.srt', '.ass', '.ssa', '.sub', '.json',
                        '.txt', '.vtt']
```
But following this advice will spit out a file extension with two dots, since the program already adds a dot character to the end of the base name.
```console
asolidtime ~> subsai -m 'guillaumekln/faster-whisper' -f '.vtt' sample\ vid.webm 
[lines excluded]
[+] Processing file: /home/maxwell/sample vid.webm
[+] Subtitles file saved to: /home/maxwell/sample vid..vtt
DONE!
```
I figured this might still be useful if you want to prepend something to the subtitle format, e.g. `-f 'autogenerated.vtt'`, so I just changed the help page of the CLI to exclude the dot:
```console
asolidtime ~> subsai --help
[lines excluded]
  -f FORMAT, --format FORMAT, --subtitles-format FORMAT
                        Output subtitles format, available formats ['srt', 'ass', 'ssa', 'sub', 'json',
                        'txt', 'vtt']
```