### PR TITLE
fix UnicodeDecodeError: 'charmap' codec can't decode byte

### DIFF
--- a/src/subsai/webui.py
+++ b/src/subsai/webui.py
@@ -515,7 +515,7 @@ def webui() -> None:
             exported_file = media_file.parent / (export_filename + export_format)
             subs.save(exported_file, fps=fps)
             st.success(f'Exported file to {exported_file}', icon="✅")
-            with open(exported_file, 'r') as f:
+            with open(exported_file, 'r', encoding='utf-8') as f:
                 st.download_button('Download', f, file_name=export_filename + export_format)
 
     with st.expander('Merge subtitles with video'):


### PR DESCRIPTION
Was getting error with Urdu .srt export, so made a quick fix.