### PR TITLE
Fix numpy compatability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ whisperx @ git+https://github.com/m-bain/whisperx.git
 stable-ts==2.13.3
 openai
 transformers
+numpy<2


### PR DESCRIPTION
fix the following error on installation
```bash
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```