### PR TITLE
GitHub Action improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,19 @@
-name: ci
+name: mkdocs
 on:
   push:
-    branches:
-      - master
-      - main
+  pull_request:
+
 permissions:
   contents: write
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}
           path: .cache
@@ -22,4 +21,7 @@ jobs:
       - run: pip install mkdocs-material
       - run: pip install mkdocstrings[python]
       - run: pip install black
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs build
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: mkdocs gh-deploy --force

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,13 +1,12 @@
-name: Publish Docker image
+name: Docker image
 
 on:
   push:
-    branches:
-      - main
+  pull_request:
 
 jobs:
-  push_to_registry:
-    name: Push Docker image to Docker Hub
+  docker_image:
+    name: Build and push Docker image
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -18,24 +17,40 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        uses: docker/login-action@v3
+        if: env.DOCKER_USERNAME != ''
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
-          images: absadiki/subsai
+          images: |
+            ${{ secrets.DOCKER_USERNAME != '' && format('{0}/subsai', secrets.DOCKER_USERNAME) || '' }}
+            ghcr.io/${{ github.repository_owner }}/subsai
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=pr
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- Bump all action versions to avoid warnings.
- CI & docker image build now run on all push / pull_request, however images and docs are only published when pushing to main.
- latest tag is applied to any push to main branch.
- Publish image to both ghcr and docker.io.

See:
https://github.com/FlyGoat/subsai/actions/runs/11630804678
https://github.com/FlyGoat/subsai/actions/runs/11630804691
https://github.com/FlyGoat/subsai/pkgs/container/subsai

For a demo run on main branch.